### PR TITLE
feat: build meta-ridgerun using Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,112 @@
+name: Meta RidgeRun Build
+
+on:
+  schedule:
+    # Runs every Monday at 5:00 AM
+    - cron: '0 5 * * 1'
+  push:
+    branches: [ "scarthgap" ]
+  workflow_dispatch:
+
+env:
+  USER: "ridgerun"
+  UID: "1000"
+  GID: "1000"
+  YOCTO_RELEASE: "scarthgap"
+  WORKSPACE: "/workdir/builder_client"
+  BUILD_DIR: "/workdir/builder_client/build"
+  META_LAYER_DIR: "/workdir/builder_client/layers/meta-ridgerun"
+
+  BITBAKE_TARGET: "gst-perf"
+  MACHINE: "jetson-agx-orin-devkit"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    container:
+      image: dchvs/yocto:scarthgap
+    timeout-minutes: 60
+    concurrency:
+      group: yocto-build
+      cancel-in-progress: false
+    steps:
+      - name: Start ssh-agent with GitLab deploy key
+        # v0.10.0 — loads the key into an in-memory ssh-agent (no key file on
+        # disk) and exports SSH_AUTH_SOCK to later steps
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555
+        with:
+          ssh-private-key: ${{ secrets.GITLAB_SSH_KEY }}
+
+      - name: Install GitLab host key
+        shell: bash
+        env:
+          GITLAB_KNOWN_HOSTS: ${{ secrets.GITLAB_KNOWN_HOSTS }}
+        run: |
+          # webfactory/ssh-agent does not manage known_hosts, so pin GitLab's host key
+          printf '%s\n' "$GITLAB_KNOWN_HOSTS" >> /etc/ssh/ssh_known_hosts
+
+      - name: Build
+        shell: bash
+        env:
+          BUILDER_REPO: ${{ secrets.BUILDER_REPO }}
+          BUILDER_RELEASE: v1.0.0
+          BUILDER_CLIENT_REPO: ${{ secrets.BUILDER_CLIENT_REPO }}
+          BUILDER_CLIENT_RELEASE: v1.0.1
+          SSTATE_MIRRORS_URL_BASE: ${{ secrets.SSTATE_MIRRORS_URL_BASE }}
+          SOURCE_LOCK_URL: ${{ secrets.SSTATE_MIRRORS_URL_BASE }}/${{ env.YOCTO_RELEASE }}/source-locks/sources-fixed-revisions_${{ env.YOCTO_RELEASE }}_latest.json
+        run: |
+          # GitHub bypasses the image ENTRYPOINT, so run its commands here.
+          getent group ${{ env.GID }} >/dev/null || groupadd --gid ${{ env.GID }} ${{ env.USER }}
+          getent passwd ${{ env.UID }} >/dev/null || useradd -p "" -l --uid ${{ env.UID }} --gid ${{ env.GID }} ${{ env.USER }} --shell /bin/bash
+
+          rm -rf $WORKSPACE
+          mkdir -p $WORKSPACE
+
+          git clone "$BUILDER_CLIENT_REPO" -b "$BUILDER_CLIENT_RELEASE" "$WORKSPACE"
+          git clone "$BUILDER_REPO" -b "$BUILDER_RELEASE" "$WORKSPACE/builder"
+
+          chown -R ${{ env.UID }}:${{ env.GID }} /workdir
+
+          gosu ${{ env.UID }}:${{ env.GID }} bash <<'EOF'
+          set -eo pipefail
+
+          cd $WORKSPACE
+          $WORKSPACE/builder/.gitlab-ci/check_sstate_server.sh
+          $WORKSPACE/builder/.gitlab-ci/verify_workspace_ownership.sh
+
+          bitbake-setup -q \
+            --setting default top-dir-prefix /workdir \
+            --setting default top-dir-name builder_client \
+            init \
+            --non-interactive \
+            --no-init-vscode \
+            --setup-dir-name $WORKSPACE \
+            --source-overrides <(curl -fsS $SOURCE_LOCK_URL) \
+            --update-bb-conf=no \
+            $WORKSPACE/builder/bitbake/config/${YOCTO_RELEASE}.conf.json default
+
+          . $BUILD_DIR/init-build-env $BUILD_DIR
+
+          git clone https://github.com/${GITHUB_REPOSITORY} -b "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" "$META_LAYER_DIR"
+          bitbake-layers add-layer $META_LAYER_DIR
+
+          echo "Build Configuration:"
+          bitbake $BITBAKE_TARGET -e | \
+            egrep '^(BB_VERSION|BUILD_SYS|NATIVELSBSTRING|TARGET_SYS|MACHINE|DISTRO|DISTRO_VERSION|TUNE_FEATURES|TARGET_FPU)=\"'
+          bitbake $BITBAKE_TARGET -e | egrep '^(RR_USE_SSTATE_MIRROR|DISTRO_FEATURES)=\"'
+
+          bitbake-layers show-layers
+
+          bitbake $BITBAKE_TARGET -q
+
+          grep -m1 "Sstate summary:" $BUILD_DIR/tmp*/log/cooker/*/console-latest.log || true
+
+          echo "Build succeeded"
+          EOF
+
+      - name: Cleanup workspace
+        if: always()
+        run: |
+          if [ -n "$WORKSPACE" ]; then
+            rm -rf $WORKSPACE/
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+pyshtables.py
+__pycache__/
+.bitbake-setup-*/
+builder/
+config/
+layers/
+site.conf
+
+sstate-cache/
+.sstate-cache/
+bitbake-cookerdaemon.log
+build/cache/
+build/downloads/
+build/tmp*/
+build/conf-upstream.*/
+build/init-build-env

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,5 +14,7 @@ BBFILE_PRIORITY_meta-ridgerun = "6"
 LAYERDEPENDS_meta-ridgerun = "core"
 LAYERSERIES_COMPAT_meta-ridgerun = "scarthgap"
 
+LAYERDIR_meta-ridgerun = "${LAYERDIR}"
+
 # RidgeRun customer GitLab order directory
 RR_CUSTOMER_GITLAB_ORDER_DIR ?= ""

--- a/recipes-core/packagegroups/packagegroup-meta-ridgerun.bb
+++ b/recipes-core/packagegroups/packagegroup-meta-ridgerun.bb
@@ -1,0 +1,26 @@
+SUMMARY = "All packages from meta-ridgerun"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+python __anonymous() {
+    import os
+    import glob
+
+    layerdir = d.getVar("LAYERDIR_meta-ridgerun")
+    if not layerdir:
+        bb.warn("Could not resolve LAYERDIR for meta-ridgerun")
+        return
+
+    pn = d.getVar("PN")
+    packages = set()
+
+    for bb_file in glob.glob(os.path.join(layerdir, "recipes-*", "*", "*.bb")):
+        recipe = os.path.splitext(os.path.basename(bb_file))[0]
+        if recipe == pn:
+            continue
+        packages.add(recipe)
+
+    if packages:
+        d.appendVar("RDEPENDS:%s" % pn, " " + " ".join(sorted(packages)))
+}

--- a/recipes-multimedia/gstreamer/gst-perf.bb
+++ b/recipes-multimedia/gstreamer/gst-perf.bb
@@ -28,3 +28,7 @@ do_configure() {
 ${S}/autogen.sh
 oe_runconf
 }
+
+do_install:append() {
+	rm -f ${D}${libdir}/gstreamer-1.0/libgstperf.a
+}


### PR DESCRIPTION
### Summary

Add a GitHub Actions workflow that builds the meta-ridgerun Yocto layer on GitHub.

### What it does

- Builds gst-perf for MACHINE=jetson-agx-orin-devkit inside the builder container.
- Triggers: weekly schedule (Mondays 05:00), every push to Scarthgap, and manual workflow_dispatch.
- Clones the branch that triggered the run (${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}) so PRs/feature branches are tested as-is and post-merge runs build Scarthgap.
- Reuses the reference build environment from Builder Client via bitbake-setup and the shared build/conf with the sstate mirror enabled.

### Notable implementation details

- Because GitHub Actions container: jobs override the image ENTRYPOINT, the workflow replicates the entrypoint's user-matching (getent/useradd/usermod) and drops to the build user with gosu, so the build runs as the unprivileged user (BitBake refuses root) and writes /workdir with matching ownership.

### Related fixes in the same change

- gst-perf recipe: drop the unshipped static libgstperf.a in do_install:append to clear the packaging QA error (matching sibling recipes).

### Testing

- Workflow runs through clone → Builder Client checkout → bitbake-setup → init-build-env → bitbake gst-perf, producing a successful build and sstate-mirror summary.

